### PR TITLE
[tracking PR] Misc fixes

### DIFF
--- a/__snapshots__/transform.test.js.snap
+++ b/__snapshots__/transform.test.js.snap
@@ -170,6 +170,7 @@ export default css\`
 
 exports[`transform dont lose top level comments 1`] = `
 "import { css } from '@emotion/core';
+
 /*
 I wondered why the baseball was getting bigger,
           and then it hit me.
@@ -515,7 +516,7 @@ export default css\`
 exports[`transform mixin with invalid js params 1`] = `
 "import { css } from '@emotion/core';
 
-function myCoolMixin(aVar, bVar /* default: red */) {
+function myCoolMixin(aVar, bVar /* FIXME: previous default was red */) {
   return css\`
     color: \${aVar};
     background: \${bVar};

--- a/__snapshots__/transform.test.js.snap
+++ b/__snapshots__/transform.test.js.snap
@@ -513,6 +513,32 @@ export default css\`
 "
 `;
 
+exports[`transform mixin using @content 1`] = `
+"import { css } from '@emotion/core';
+
+function coolContents(content) {
+  return css\`
+    \${content};
+  \`;
+}
+
+function coolContentsArgs(a, b, content) {
+  return css\`
+    color: \${a};
+    background: \${b};
+    \${content};
+  \`;
+}
+
+export default css\`
+  color: red;
+  \${coolContents(css([css('text-decoration: none')]))}
+
+  \${coolContentsArgs('yellow', 'blue', css([css('font-weight: bold')]))}
+\`;
+"
+`;
+
 exports[`transform mixin with invalid js params 1`] = `
 "import { css } from '@emotion/core';
 

--- a/__snapshots__/transform.test.js.snap
+++ b/__snapshots__/transform.test.js.snap
@@ -555,6 +555,29 @@ export default css\`
 "
 `;
 
+exports[`transform mixin with nested @include 1`] = `
+"import { css } from '@emotion/core';
+
+function myMixin() {
+  return css\`
+    color: blue;
+  \`;
+}
+
+function anotherMixin() {
+  return css\`
+    \${myMixin()};
+    font-weight: bold;
+  \`;
+}
+
+export default css\`
+  text-decoration: none;
+  \${anotherMixin()}
+\`;
+"
+`;
+
 exports[`transform mixins nested 1`] = `
 "import { css } from '@emotion/core';
 import { variables as vars } from '@domain-group/fe-brary';

--- a/__snapshots__/transform.test.js.snap
+++ b/__snapshots__/transform.test.js.snap
@@ -34,7 +34,8 @@ export default css\`
 
 exports[`transform check if var declared locally before importing 1`] = `
 "import { css } from '@emotion/core';
-import { variables as vars, simpleArrow } from '@domain-group/fe-brary';
+import { variables as vars } from '@domain-group/fe-brary';
+import { simpleArrow } from '../utils';
 
 const mapMarkerArrowSize = '8px';
 
@@ -97,7 +98,8 @@ export default css\`
 
 exports[`transform custom vars in include 1`] = `
 "import { css } from '@emotion/core';
-import { variables as vars, simpleArrow } from '@domain-group/fe-brary';
+import { variables as vars } from '@domain-group/fe-brary';
+import { simpleArrow } from '../utils';
 
 const mapMarkerArrowSize = '8px';
 
@@ -221,6 +223,44 @@ export const foo = css\`
 "
 `;
 
+exports[`transform handle comment blocks 1`] = `
+"import { css } from '@emotion/core';
+
+// // foo
+// // bar
+/*
+I wondered why the baseball was getting bigger,
+          and then it hit me.
+*/
+export const bar = css\`
+  color: pink;
+\`;
+
+// foo bar baz
+// skeleton washing his hair
+// bear washing clothes
+export const foo = css\`
+  color: black;
+\`;
+"
+`;
+
+exports[`transform handle comments with backticks 1`] = `
+"import { css } from '@emotion/core';
+
+export const bar = css\`
+  /*
+            Really cool \\\\\`comment\\\\\` with \\\\\`backticks\\\\\`!
+          */
+  color: pink;
+\`;
+
+export const foo = css\`
+  color: black; // an inline \\\\\`comment\\\\\` with \\\\\`backticks\\\\\`
+\`;
+"
+`;
+
 exports[`transform handle mixins without args 1`] = `
 "import { css } from '@emotion/core';
 
@@ -273,7 +313,8 @@ export default css\`
 
 exports[`transform imports fe-brary helpers with @extend 1`] = `
 "import { css } from '@emotion/core';
-import { variables as vars, buttonNormalize } from '@domain-group/fe-brary';
+import { variables as vars } from '@domain-group/fe-brary';
+import { buttonNormalize } from '../utils';
 
 export const agentDetailsRightArrow = css\`
   \${buttonNormalize};
@@ -288,7 +329,7 @@ export const anotherRef = css\`
 
 exports[`transform imports fe-brary helpers with @include 1`] = `
 "import { css } from '@emotion/core';
-import { resetTopMargin } from '@domain-group/fe-brary';
+import { resetTopMargin } from '../utils';
 
 export default css\`
   \${resetTopMargin()}
@@ -322,7 +363,7 @@ export default css\`
 
 exports[`transform locate multi comma rule composition ref just after shared css 1`] = `
 "import { css } from '@emotion/core';
-import { buttonNormalize } from '@domain-group/fe-brary';
+import { buttonNormalize } from '../utils';
 import { arrowColor } from '../variables';
 
 export const bar = css\`
@@ -471,6 +512,22 @@ export default css\`
 "
 `;
 
+exports[`transform mixin with invalid js params 1`] = `
+"import { css } from '@emotion/core';
+
+function myCoolMixin(aVar, bVar /* default: red */) {
+  return css\`
+    color: \${aVar};
+    background: \${bVar};
+  \`;
+}
+
+export default css\`
+  \${myCoolMixin('yellow', 'green')}
+\`;
+"
+`;
+
 exports[`transform mixins nested 1`] = `
 "import { css } from '@emotion/core';
 import { variables as vars } from '@domain-group/fe-brary';
@@ -589,8 +646,8 @@ export const fooBarBaz = css\`
 
 exports[`transform never print nested  1`] = `
 "import { css } from '@emotion/core';
-import { variables as vars, fontSmall, aTag } from '@domain-group/fe-brary';
-import { fePaListingDetailsWrapper, fePaListingDetailsHeading } from '../utils';
+import { variables as vars } from '@domain-group/fe-brary';
+import { fePaListingDetailsWrapper, fePaListingDetailsHeading, fontSmall, aTag } from '../utils';
 
 export const aboutDevelopment = css\`
   \${fePaListingDetailsWrapper};
@@ -653,8 +710,7 @@ export const additionalFeaturesListing = css\`
 
 exports[`transform no new line breaks 1`] = `
 "import { css } from '@emotion/core';
-import { aTag } from '@domain-group/fe-brary';
-import { fePaListingDetailsWrapper } from '../utils';
+import { fePaListingDetailsWrapper, aTag } from '../utils';
 
 export const aboutDevelopment = css\`
   \${fePaListingDetailsWrapper};

--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ function scssFileToJs(filePath) {
         path.dirname(scssFileToJs(path.resolve(filePath))),
         path.join(process.cwd(), 'src', 'styles'),
       );
+
       const js = transform(
         css,
         filePath,

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const chalk = require('chalk');
 const transform = require('./transform');
 
 function scssFileToJs(filePath) {
-  const newFilePath = filePath.replace('/scss/', '/styles/').replace('.scss', '.js');
+  const newFilePath = filePath.replace('/scss/', '/styles/').replace('.scss', '.emotion.js');
   const filenewFilePathDir = path.dirname(newFilePath);
   const filenewFilePathBase = path.basename(newFilePath);
 

--- a/package.json
+++ b/package.json
@@ -28,8 +28,5 @@
   },
   "engines": {
     "node": ">10.12.0"
-  },
-  "optionalDependencies": {
-    "@domain-group/fe-brary": "^26.2.1"
   }
 }

--- a/transform.js
+++ b/transform.js
@@ -682,9 +682,14 @@ module.exports = (cssString, filePath, pathToVariables = '../variables') => {
       }
 
       if (type === 'mixin') {
-        // Replace any instance of @content with the new parameter `content` that's
-        // now in scope - our @include code will pass it in
-        const filteredContentsAtRule = contents.replace(/\@content/g, '${content}');
+        const filteredContentsAtRule = contents
+          // Replace any instance of @content with the new parameter `content` that's
+          // now in scope - our @include code will pass it in
+          .replace(/\@content/g, '${content}')
+          // Replace @include since it's never valid inside a css`` mixin body
+          // (we already properly include the mixin via js template literal)
+          .replace(/\@include/g, '');
+
         return `${acc}\n${isUsedInFile ? '' : 'export '}${
           oneDefault && !isUsedInFile ? ' default ' : ''
         }function ${name} {\n  return css\`${filteredContentsAtRule}\n  \`;\n}\n`;

--- a/transform.test.js
+++ b/transform.test.js
@@ -165,6 +165,33 @@ describe('transform', () => {
       ).toMatchSnapshot();
   });
 
+  it('mixin using @content', () => {
+      expect(
+          transform(`
+        @mixin cool-contents {
+          @content;
+        }
+
+        @mixin cool-contents-args($a, $b) {
+          color: $a;
+          background: $b;
+          @content;
+        }
+
+        .foo {
+          color: red;
+          @include cool-contents {
+            text-decoration: none;
+          }
+          @include cool-contents-args(yellow, blue) {
+            font-weight: bold;
+          }
+        }
+      `)
+      ).toMatchSnapshot();
+
+  });
+
   it('non classname', () => {
     expect(
       transform(

--- a/transform.test.js
+++ b/transform.test.js
@@ -928,7 +928,7 @@ describe('transform', () => {
     ).toMatchSnapshot();
   });
 
-  it.only('handle comment blocks', () => {
+  it('handle comment blocks', () => {
       expect(
           transform(`
           //// foo

--- a/transform.test.js
+++ b/transform.test.js
@@ -192,6 +192,26 @@ describe('transform', () => {
 
   });
 
+  it('mixin with nested @include', () => {
+      expect(
+          transform(`
+        @mixin my-mixin {
+          color: blue;
+        }
+
+        @mixin another-mixin {
+          @include my-mixin;
+          font-weight: bold;
+        }
+
+        .foo {
+          text-decoration: none;
+          @include another-mixin;
+        }
+      `)
+      ).toMatchSnapshot();
+  });
+
   it('non classname', () => {
     expect(
       transform(

--- a/transform.test.js
+++ b/transform.test.js
@@ -147,6 +147,24 @@ describe('transform', () => {
     ).toMatchSnapshot();
   });
 
+  it('mixin with invalid js params', () => {
+      expect(
+          transform(`
+        @mixin my-cool-mixin(
+          $a-var,
+          $b-var: red,
+        ) {
+          color: $a-var;
+          background: $b-var;
+        }
+
+        .foo {
+          @include my-cool-mixin(yellow, green);
+        }
+      `)
+      ).toMatchSnapshot();
+  });
+
   it('non classname', () => {
     expect(
       transform(
@@ -908,6 +926,47 @@ describe('transform', () => {
         }
       `),
     ).toMatchSnapshot();
+  });
+
+  it.only('handle comment blocks', () => {
+      expect(
+          transform(`
+          //// foo
+          //// bar
+
+        /*
+          I wondered why the baseball was getting bigger,
+          and then it hit me.
+         */
+        .bar {
+          color: pink;
+        }
+
+        // foo bar baz
+        // skeleton washing his hair
+        // bear washing clothes
+        .foo {
+          color: black;
+        }
+      `)
+      ).toMatchSnapshot();
+  });
+
+  it('handle comments with backticks', () => {
+      expect(
+          transform(`
+        .bar {
+          /*
+            Really cool \`comment\` with \`backticks\`!
+          */
+          color: pink;
+        }
+
+        .foo {
+          color: black; // an inline \`comment\` with \`backticks\`
+        }
+      `)
+      ).toMatchSnapshot();
   });
 
   it('check if var declared locally before importing', () => {


### PR DESCRIPTION
Making this draft PR to track my fixes and tweaks in the `misc-fixes` branch on this fork.

Ideally, I'll upstream the changes that are pure fixes, but some changes might be more controversial and for ease of development I'm leaving them in this single branch for now. Otherwise I'd have to either merge smaller branches into my fork and diverge from upstream master, or create several smaller branches and deal with juggling those.

---

Source of truth will always be the commits outlined below, but a summary of things changed is:

**Notable bugs fixed**:

* handle cases where the closed-source `feBrary` library is not installed without crashing
* handle comments with backticks so that wrapping them with the `css` template literal is valid js
* handle comment blocks
* handle mixin params that aren't already valid js identifiers
* support mixins that use @content, avoid double-including the mixin in that case
* support `@include` inside `@mixin` bodies

**QOL tweaks** (possibly not suitable for upstream):

* output emotion files are now suffixed with `.emotion.js` to avoid name collisions (it's common to have `Button.js` and `Button.scss` living alongside, and the default behaviour would wipe out `Button.js`
* the closed-source `@domain-group/fe-brary` dep is removed, since it breaks `yarn install` as mentioned in the README (the dependency is not public)
